### PR TITLE
Doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 * [Install Vagrant](http://www.vagrantup.com/download)
 * Create a working directory and `cd` into it
-* Install Vagrant plugins: `vagrant plugin install vagrant-hostmanager vagrant-parallels`
-* Get Vagrantfile: `curl -O http://vagrant.magehost.pro/Vagrantfile`
+* Install Vagrant plugins: `vagrant plugin install vagrant-hostmanager`
+* Get Vagrantfile: `curl -OL https://vagrant.magehost.pro/Vagrantfile`
 * Start VM: `vagrant up`
+
+
+Visit [vagrant.magehost.pro](https://vagrant.magehost.pro/) for more info on getting started and different providers (Virtualbox, Parallels, VMware)

--- a/pub/index.html
+++ b/pub/index.html
@@ -95,7 +95,7 @@
         </li>
         <li>Create a working directory and <code>cd</code> into it</li>
         <li>Install Vagrant hostmanager plugin: <br /><code>vagrant plugin install vagrant-hostmanager</code></li>
-        <li>Get our <a href="http://vagrant.magehost.pro/Vagrantfile" target="_blank">Vagrantfile</a>: <br /><code>curl -O http://vagrant.magehost.pro/Vagrantfile</code></li>
+        <li>Get our <a href="https://vagrant.magehost.pro/Vagrantfile" target="_blank">Vagrantfile</a>: <br /><code>curl -OL https://vagrant.magehost.pro/Vagrantfile</code></li>
         <li>Start Vagrant box: <br /><code>vagrant up</code></li>
       </ul>
     </div>


### PR DESCRIPTION
The current curl command caused the Vagrant file to have 301 html as it doesn't follow the redirect to https. Url was corrected and the -L param added to follow redirects in case the URL changes in the future.

Removed the vagrant-parallels plugin from plugin install instructions as it is optional. Added a link to the detailed docs to explain setting up providers.